### PR TITLE
スコア計算の実装、スコアテーブルからmodeの削除

### DIFF
--- a/src/model/score.go
+++ b/src/model/score.go
@@ -5,10 +5,9 @@ import "time"
 type Score struct {
 	ID         uint      `json:"id" gorm:"primaryKey"`
 	Point      uint      `json:"point"`
-	Time       uint      `json:"time" gorm:"not null"`
+	Time       float64   `json:"time" gorm:"not null"`
 	MissCount  uint      `json:"miss_count"`
-	Mode       string    `json:"mode" gorm:"not null"`
-	Difficulty string    `json:"difficulty" gorm:"not null"`
+	Difficulty string    `json:"difficulty"`
 	UserID     uint      `json:"user_id" gorm:"not null"`
 	User       User      `json:"user" gorm:"foreignKey:UserID; constraint:OnDelete:CASCADE"`
 	QuizID     uint      `json:"quiz_id" gorm:"not null"`

--- a/src/usecase/score_usecase.go
+++ b/src/usecase/score_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"api/model"
 	"api/repository"
+	"math"
 )
 
 type IScoreUsecase interface {
@@ -36,6 +37,14 @@ func (su *scoreUsecase) GetFilteredScores(filters []model.Filter) ([]model.Score
 }
 
 func (su *scoreUsecase) CreateScore(score model.Score) (model.ScoreResponse, error) {
+
+	// ポイントを計算
+	penalty := 10 //ミスのペナルティ(秒数)
+	point := math.Pow(0.99, score.Time+float64(uint(penalty)*score.MissCount)) * 10000
+	roundedPoint := math.Round(point)
+
+	score.Point = uint(roundedPoint)
+
 	if err := su.sr.CreateScore(&score); err != nil {
 		return model.ScoreResponse{}, err
 	}


### PR DESCRIPTION
スコアでTime(秒数)とMissCount(間違えた回数)を入力することで具体的な得点を計算して登録できるようになりました。